### PR TITLE
[Enhancement] Add option to reverse order of crumbs

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -31,11 +31,12 @@ export default Component.extend({
   layout,
   tagName: 'ol',
   linkable: true,
+  reverse: false,
   classNameBindings: [ 'breadCrumbClass' ],
   hasBlock: computed.bool('template').readOnly(),
   currentRouteName: computed.readOnly('applicationController.currentRouteName'),
 
-  routeHierarchy: computed('currentRouteName', {
+  routeHierarchy: computed('currentRouteName', 'reverse', {
     get() {
       const currentRouteName = getWithDefault(this, 'currentRouteName', false);
 
@@ -44,7 +45,8 @@ export default Component.extend({
       const routeNames = this._splitCurrentRouteName(currentRouteName);
       const filteredRouteNames = this._filterIndexRoutes(routeNames);
 
-      return this._lookupBreadCrumb(routeNames, filteredRouteNames);
+      const crumbs = this._lookupBreadCrumb(routeNames, filteredRouteNames);
+      return this.get('reverse') ? crumbs.reverse() : crumbs;
     },
 
     set() {

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -128,3 +128,29 @@ test('routes with no breadcrumb should render with their capitalized inferred na
     assert.ok(hasCookieText, 'renders the right inferred name');
   });
 });
+
+test('absence of reverse option renders breadcrumb right to left', function(assert) {
+  assert.expect(2);
+  visit('/foo/bar/baz');
+
+  andThen(() => {
+    const numberOfRenderedBreadCrumbs = find('#bootstrapLinkable li').length;
+    assert.equal(numberOfRenderedBreadCrumbs, 3, 'renders the correct number of breadcrumbs');
+    assert.deepEqual(
+      Ember.$('#bootstrapLinkable li').map((idx, item) => item.innerText.trim()).toArray(),
+      ['I am Foo Index', 'I am Bar', 'I am Baz']);
+  });
+});
+
+test('reverse option = TRUE renders breadcrumb from left to right', function(assert) {
+  assert.expect(2);
+  visit('/foo/bar/baz');
+
+  andThen(() => {
+    const numberOfRenderedBreadCrumbs = find('#reverseBootstrapLinkable li').length;
+    assert.equal(numberOfRenderedBreadCrumbs, 3, 'renders the correct number of breadcrumbs');
+    assert.deepEqual(
+      Ember.$('#reverseBootstrapLinkable li').map((idx, item) => item.innerText.trim()).toArray(),
+      ['I am Baz', 'I am Bar', 'I am Foo Index']);
+  });
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -23,4 +23,7 @@
   {{/if}}
 {{/bread-crumbs}}
 
+<h2>Reverse (bootstrap linkable)</h2>
+{{bread-crumbs id="reverseBootstrapLinkable" reverse=true}}
+
 {{outlet}}


### PR DESCRIPTION
![screen shot 2015-05-30 at 4 03 58 pm](https://cloud.githubusercontent.com/assets/558005/7899767/924f7f1c-06e5-11e5-8ee8-85da88217cfd.png)
![screen shot 2015-05-30 at 4 04 02 pm](https://cloud.githubusercontent.com/assets/558005/7899766/9202fe58-06e5-11e5-9e51-a6a27701ac5b.png)

This is needed for a situation where the breadcrumb is right-aligned on the page, with the "current" route being the left most "crumb"