### PR TITLE
Adding support for changing dynamic segments.

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -20,9 +20,10 @@ export default Component.extend({
   reverse: false,
   classNameBindings: [ 'breadCrumbClass' ],
   hasBlock: computed.bool('template').readOnly(),
-  currentRouteName: computed.readOnly('applicationController.currentRouteName'),
+  currentUrl: computed.readOnly('applicationRoute.router.url'),
+  currentRouteName: computed.readOnly('applicationRoute.controller.currentRouteName'),
 
-  routeHierarchy: computed('currentRouteName', 'reverse', {
+  routeHierarchy: computed('currentUrl', 'reverse', {
     get() {
       const currentRouteName = getWithDefault(this, 'currentRouteName', false);
 

--- a/addon/initializers/crumbly.js
+++ b/addon/initializers/crumbly.js
@@ -1,5 +1,5 @@
 export function initialize(container, application) {
-  application.inject('component:bread-crumbs', 'applicationController', 'controller:application');
+  application.inject('component:bread-crumbs', 'applicationRoute', 'route:application');
 }
 
 export default {

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -192,3 +192,20 @@ test('bread-crumbs change when the route is changed', function(assert) {
     assert.equal(lastCrumbText, 'I am Foo Index', 'renders the correct last breadcrumb (after transition)');
   });
 });
+
+test('bread-crumbs component updates when dynamic segments change', function(assert) {
+  assert.expect(4);
+  visit('/foo/bar/baz/1');
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'foo.bar.baz.show-with-params', 'correct current route name');
+    assert.equal(Ember.$('#bootstrapLinkable li:last-child a')[0].innerText.trim(), 'Derek Zoolander', 'crumb is based on dynamic segment');
+  });
+
+  click('#hansel');
+
+  andThen(() => {
+    assert.equal(currentRouteName(), 'foo.bar.baz.show-with-params', 'correct current route name');
+    assert.equal(Ember.$('#bootstrapLinkable li:last-child a')[0].innerText.trim(), 'Hansel McDonald', 'crumb is based on dynamic segment');
+  });
+});

--- a/tests/dummy/app/foo/bar/baz/show-with-params/route.js
+++ b/tests/dummy/app/foo/bar/baz/show-with-params/route.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+
+const {
+  Route,
+  get,
+  set
+} = Ember;
+
+export default Route.extend({
+  breadCrumb: {},
+
+  model(params) {
+    let models = [
+      { name: 'Derek Zoolander' },
+      { name: 'Hansel McDonald' }
+    ];
+
+    // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+    return models[(params.model_id - 1)];
+    // jscs:enable
+  },
+
+  afterModel(model) {
+    const name = get(model, 'name');
+
+    const fashionModel = {
+      title: name
+    };
+
+    set(this, 'breadCrumb', fashionModel);
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,7 @@ Router.map(function() {
       this.route('baz', function() {
         this.route('hidden');
         this.route('show');
+        this.route('show-with-params', { path: '/:model_id' });
       });
     });
   });

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+const {
+  Route
+} = Ember;
+
+export default Route.extend({
+});

--- a/tests/dummy/app/templates/foo/bar/baz/show-with-params.hbs
+++ b/tests/dummy/app/templates/foo/bar/baz/show-with-params.hbs
@@ -1,0 +1,2 @@
+{{#link-to "foo.bar.baz.show-with-params" 1 id="zoolander"}}Zoolander{{/link-to}}
+{{#link-to "foo.bar.baz.show-with-params" 2 id="hansel"}}Hansel{{/link-to}}


### PR DESCRIPTION
Currently if you change a dynamic segment in a URL the `applicationController.currentRouteName` remains the same (e.g., if a URL changes from `/users/poteto` to `/users/gmurphey`, the `currentRouteName` remains `users.user`).

Unfortunately, the `ApplicationController` only has access to `currentRouteName` and `currentPath`; neither of which is aware of dynamic segments. The easiest way to get around this was to inject `route:application` into `component:bread-crumbs`, where you can access `applicationRoute.router.url`, and base crumb computation off changes to the `url`.