### PR TITLE
Default linkable for last crumb should be false by default

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -78,12 +78,16 @@ export default Component.extend({
   },
 
   _lookupBreadCrumb(routeNames, filteredRouteNames) {
-    const defaultLinkable = get(this, 'linkable');
+    let defaultLinkable = get(this, 'linkable');
+    const pathLength = routeNames.length;
     const breadCrumbs = filteredRouteNames.map((name, index) => {
       const path = this._guessRoutePath(routeNames, name, index);
       let breadCrumb = this._lookupRoute(path).getWithDefault('breadCrumb', undefined);
       const breadCrumbType = typeOf(breadCrumb);
 
+      if(index === pathLength - 1) {
+        defaultLinkable = false;
+      }
       if (breadCrumbType === 'undefined') {
         breadCrumb = {
           path,

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -85,7 +85,7 @@ export default Component.extend({
       let breadCrumb = this._lookupRoute(path).getWithDefault('breadCrumb', undefined);
       const breadCrumbType = typeOf(breadCrumb);
 
-      if(index === pathLength - 1) {
+      if (index === pathLength - 1) {
         defaultLinkable = false;
       }
       if (breadCrumbType === 'undefined') {

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -207,13 +207,13 @@ test('bread-crumbs component updates when dynamic segments change', function(ass
 
   andThen(() => {
     assert.equal(currentRouteName(), 'foo.bar.baz.show-with-params', 'correct current route name');
-    assert.equal(Ember.$('#bootstrapLinkable li:last-child a')[0].innerText.trim(), 'Derek Zoolander', 'crumb is based on dynamic segment');
+    assert.equal(Ember.$('#bootstrapLinkable li:last-child')[0].innerText.trim(), 'Derek Zoolander', 'crumb is based on dynamic segment');
   });
 
   click('#hansel');
 
   andThen(() => {
     assert.equal(currentRouteName(), 'foo.bar.baz.show-with-params', 'correct current route name');
-    assert.equal(Ember.$('#bootstrapLinkable li:last-child a')[0].innerText.trim(), 'Hansel McDonald', 'crumb is based on dynamic segment');
+    assert.equal(Ember.$('#bootstrapLinkable li:last-child')[0].innerText.trim(), 'Hansel McDonald', 'crumb is based on dynamic segment');
   });
 });

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -108,15 +108,23 @@ test('bread-crumbs component accepts a block', function(assert) {
 });
 
 test('routes with no breadcrumb should render with their capitalized inferred name', function(assert) {
-  assert.expect(2);
+  assert.expect(4);
   visit('/dessert/cookie');
 
   andThen(() => {
-    const listItemsText = find('ol#bootstrapLinkable li a').text();
-    const hasDessertText = listItemsText.indexOf('Dessert') >= 0;
-    const hasCookieText = listItemsText.indexOf('Cookie') >= 0;
-    assert.ok(hasDessertText, 'renders the right inferred name');
-    assert.ok(hasCookieText, 'renders the right inferred name');
+    const allListItems = find('ol#bootstrapLinkable li').text();
+    const allLinkItems = find('ol#bootstrapLinkable li a').text();
+
+    const hasDessertInallList = allListItems.indexOf('Dessert') >= 0;
+    const hasCookieTextInallList = allListItems.indexOf('Cookie') >= 0;
+
+    const hasDessertInLinkList = allLinkItems.indexOf('Dessert') >= 0;
+    const doesNotHaveCookieInLinkList = allLinkItems.indexOf('Cookie') === -1;
+
+    assert.ok(hasDessertInallList, 'renders the right inferred name');
+    assert.ok(hasCookieTextInallList, 'renders the right inferred name');
+    assert.ok(hasDessertInLinkList, 'renders the right inferred name');
+    assert.ok(doesNotHaveCookieInLinkList, 'renders the right inferred name');
   });
 });
 


### PR DESCRIPTION
This PR ensures that the default linkable for the last crumb will be always false unless specified from the route. Will close #21