### PR TITLE
Fix loading state not showing up in breadcrumbs

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -23,7 +23,7 @@ export default Component.extend({
   currentUrl: computed.readOnly('applicationRoute.router.url'),
   currentRouteName: computed.readOnly('applicationRoute.controller.currentRouteName'),
 
-  routeHierarchy: computed('currentUrl', 'reverse', {
+  routeHierarchy: computed('currentUrl', 'currentRouteName', 'reverse', {
     get() {
       const currentRouteName = getWithDefault(this, 'currentRouteName', false);
 


### PR DESCRIPTION
Loading states stopped showing up in my app from updating to 0.2.1 (from 0.2.0).

I'm not really experienced with testing route substates, so I sadly have no test for this..