### PR TITLE
Add isTail and isHead to breadcrumb data

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -80,7 +80,6 @@ export default Component.extend({
     let defaultLinkable = get(this, 'linkable');
     const pathLength = routeNames.length;
     const breadCrumbs = filteredRouteNames.map((name, index) => {
-      let isTail = false;
       const path = this._guessRoutePath(routeNames, name, index);
       const route = this._lookupRoute(path);
 
@@ -90,9 +89,9 @@ export default Component.extend({
       const breadCrumbType = typeOf(breadCrumb);
 
       let isHead = index === 0;
+      let isTail = index === filteredRouteNames.length - 1;
 
       if (index === pathLength - 1) {
-        isTail = true;
         defaultLinkable = false;
       }
       if (breadCrumbType === 'undefined') {

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -80,6 +80,7 @@ export default Component.extend({
     let defaultLinkable = get(this, 'linkable');
     const pathLength = routeNames.length;
     const breadCrumbs = filteredRouteNames.map((name, index) => {
+      let isTail = false;
       const path = this._guessRoutePath(routeNames, name, index);
       const route = this._lookupRoute(path);
 
@@ -88,12 +89,17 @@ export default Component.extend({
       let breadCrumb = getWithDefault(route, 'breadCrumb', undefined);
       const breadCrumbType = typeOf(breadCrumb);
 
+      let isHead = index === 0;
+
       if (index === pathLength - 1) {
+        isTail = true;
         defaultLinkable = false;
       }
       if (breadCrumbType === 'undefined') {
         breadCrumb = {
           path,
+          isTail,
+          isHead,
           linkable: defaultLinkable,
           title: classify(name)
         };
@@ -102,6 +108,8 @@ export default Component.extend({
       } else {
         setProperties(breadCrumb, {
           path,
+          isTail,
+          isHead,
           linkable: breadCrumb.hasOwnProperty('linkable') ? breadCrumb.linkable : defaultLinkable
         });
       }

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -79,9 +79,13 @@ export default Component.extend({
   _lookupBreadCrumb(routeNames, filteredRouteNames) {
     const defaultLinkable = get(this, 'linkable');
     const pathLength = routeNames.length;
+    const filteredRouteLength = filteredRouteNames.length;
     const breadCrumbs = filteredRouteNames.map((name, index) => {
       const path = this._guessRoutePath(routeNames, name, index);
       const route = this._lookupRoute(path);
+      const isHead = index === 0;
+      const isTail = index === filteredRouteLength - 1;
+
       const crumbLinkable = (index === pathLength - 1) ? false : defaultLinkable;
 
       assert(`[ember-crumbly] \`route:${path}\` was not found`, route);
@@ -95,6 +99,8 @@ export default Component.extend({
       } else {
         setProperties(breadCrumb, {
           path,
+          isHead,
+          isTail,
           linkable: breadCrumb.hasOwnProperty('linkable') ? breadCrumb.linkable : crumbLinkable
         });
       }

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -76,6 +76,19 @@ test('routes can set dynamic breadcrumb props', function(assert) {
   });
 });
 
+test('breadcrumb data includes isTail and isHead', function(assert) {
+  assert.expect(3);
+  visit('/foo/bar/baz/show');
+
+  andThen(() => {
+    const routeHierarchy = componentInstance.get('routeHierarchy');
+
+    assert.equal(routeHierarchy[0].isHead, true, 'first route is head');
+    assert.equal(routeHierarchy[1].isHead, false, 'last route is not head');
+    assert.equal(routeHierarchy[routeHierarchy.length - 1].isTail, true, 'last route is tail');
+  });
+});
+
 test('routes that are not linkable do not generate an <a> tag', function(assert) {
   assert.expect(3);
   visit('/foo/bar/baz/');

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -77,14 +77,15 @@ test('routes can set dynamic breadcrumb props', function(assert) {
 });
 
 test('breadcrumb data includes isTail and isHead', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
   visit('/foo/bar/baz/show');
 
   andThen(() => {
     const routeHierarchy = componentInstance.get('routeHierarchy');
 
     assert.equal(routeHierarchy[0].isHead, true, 'first route is head');
-    assert.equal(routeHierarchy[1].isHead, false, 'last route is not head');
+    assert.equal(routeHierarchy[1].isHead, false, 'second route is not head');
+    assert.equal(routeHierarchy[0].isTail, false, 'first route is not tail');
     assert.equal(routeHierarchy[routeHierarchy.length - 1].isTail, true, 'last route is tail');
   });
 });

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -90,6 +90,19 @@ test('breadcrumb data includes isTail and isHead', function(assert) {
   });
 });
 
+test('first route is tail and head when on root', function(assert) {
+  assert.expect(3);
+  visit('/foo');
+
+  andThen(() => {
+    const routeHierarchy = componentInstance.get('routeHierarchy');
+
+    assert.equal(routeHierarchy.length, 1, 'There is 1 route');
+    assert.equal(routeHierarchy[0].isHead, true, 'first route is head');
+    assert.equal(routeHierarchy[0].isTail, true, 'first route is tail');
+  });
+});
+
 test('routes that are not linkable do not generate an <a> tag', function(assert) {
   assert.expect(3);
   visit('/foo/bar/baz/');


### PR DESCRIPTION
This allows for advanced customisations where you need to customise the first or last crumb. In my use case I need to make the last crumb a dropdown menu, similar to Google Drive.
