### PR TITLE
Handling flat top-level routes

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -63,7 +63,9 @@ export default Component.extend({
     const routes = routeNames.slice(0, index + 1);
 
     if (routes.length === 1) {
-      return `${name}.index`;
+      let path = `${name}.index`;
+
+      return (this._lookupRoute(path)) ? path : name;
     }
 
     return routes.join('.');
@@ -76,7 +78,6 @@ export default Component.extend({
   _lookupRoute(routeName) {
     const container = get(this, 'container');
     const route = container.lookup(`route:${routeName}`);
-    assert(`[ember-crumbly] \`route:${routeName}\` was not found`, route);
 
     return route;
   },
@@ -86,7 +87,11 @@ export default Component.extend({
     const pathLength = routeNames.length;
     const breadCrumbs = filteredRouteNames.map((name, index) => {
       const path = this._guessRoutePath(routeNames, name, index);
-      let breadCrumb = this._lookupRoute(path).getWithDefault('breadCrumb', undefined);
+      const route = this._lookupRoute(path);
+
+      assert(`[ember-crumbly] \`route:${path}\` was not found`, route);
+
+      let breadCrumb = route.getWithDefault('breadCrumb', undefined);
       const breadCrumbType = typeOf(breadCrumb);
 
       if (index === pathLength - 1) {

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -48,6 +48,21 @@ test('routes that opt-out are not shown', function(assert) {
   });
 });
 
+test('top-level flat routes render correctly', function(assert) {
+  assert.expect(4);
+  visit('/about');
+
+  andThen(() => {
+    const $breadCrumbs = find('#foundationLinkable li');
+    const routeHierarchy = componentInstance.get('routeHierarchy');
+    const numberOfRenderBreadCrumbs = $breadCrumbs.length;
+    assert.equal(currentRouteName(), 'about', 'correct current route name');
+    assert.equal(routeHierarchy.length, 1, 'returns correct number of routes');
+    assert.equal(numberOfRenderBreadCrumbs, 1, 'renders the correct number of breadcrumbs');
+    assert.equal($breadCrumbs.first().text().trim(), 'About Derek Zoolander', 'uses flat route breadcrumb settings');
+  });
+});
+
 test('routes can set dynamic breadcrumb props', function(assert) {
   assert.expect(5);
   visit('/foo/bar/baz/show');

--- a/tests/dummy/app/about/route.js
+++ b/tests/dummy/app/about/route.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  breadCrumb: {
+    title: 'About Derek Zoolander'
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -28,6 +28,8 @@ Router.map(function() {
   this.route('dessert', function() {
     this.route('cookie');
   });
+
+  this.route('about');
 });
 
 export default Router;


### PR DESCRIPTION
I'm not sure if this is the best implementation since you have to lookup the route twice if it's to the top-level route, but this will handle flat top-level routes (`route:about` if `route:about.index` doesn't exist, for example). 

Closes #33 
Closes #35
Closes #50 