### PR TITLE
Updating ember-suave@1.2.3.

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,3 @@
+{
+  "preset": "ember-suave"
+}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-suave": "1.0.0",
+    "ember-suave": "1.2.3",
     "ember-try": "0.0.6"
   },
   "keywords": [


### PR DESCRIPTION
The develop branch tests are currently failing against Node v0.12 because of an issue between broccoli-jscs and ember-suave. Updating ember-suave to 1.2.3 seems to fix this issue.