### PR TITLE
Removes outputStyle option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ This addon is tested against the `release`, `beta` and `canary` channels, and ex
 Basic usage is simple, just add the Component to any template in your application:
 
 ```hbs
-{{bread-crumbs tagName="ol" outputStyle="bootstrap" linkable=true}}
-{{bread-crumbs tagName="ul" outputStyle="foundation" linkable=false}}
+{{bread-crumbs linkable=true}}
+{{bread-crumbs linkable=false}}
 ```
 
-This will automatically output the current route's hierarchy as a clickable breadcrumb in a HTML structure that Bootstrap or Foundation expects. By default, the Component will simply display the route's inferred name.
+This will automatically output the current route's hierarchy as a clickable breadcrumb. By default, the Component will simply display the route's inferred name.
 
 For example, the route `foo/bar/baz/1` will generate the following breadcrumb: `Foo > Bar > Baz > Show`. In most cases, this won't be exactly how you'd like it, so you can use the following declarative API to update the breadcrumb labels:
 
@@ -103,7 +103,7 @@ export default Ember.Route.extend({
 ```
 
 ```hbs
-{{#bread-crumbs outputStyle="bootstrap" linkable=true as |component cow|}}
+{{#bread-crumbs linkable=true as |component cow|}}
   {{#bread-crumb route=cow breadCrumbs=component}}
     {{#if cow.title}}
       {{cow.title}}
@@ -160,7 +160,7 @@ Will generate the following breadcrumb: `_Animals_ > Quadrupeds > _Cows_ > Cows 
 You can set your own `li` classes by passing in the appropriate `crumbClass` to the Component:
 
 ```hbs
-{{bread-crumbs tagName="ul" outputStyle="foundation" linkable=true crumbClass="breadcrumb-item"}}
+{{bread-crumbs tagName="ul" linkable=true crumbClass="breadcrumb-item"}}
 ```
 
 Which generates the following HTML:
@@ -187,7 +187,7 @@ Which generates the following HTML:
 You can set your own `a` classes by passing in the appropriate `linkClass` to the Component:
 
 ```hbs
-{{bread-crumbs tagName="ul" outputStyle="foundation" linkable=true linkClass="breadcrumb-link"}}
+{{bread-crumbs tagName="ul" linkable=true linkClass="breadcrumb-link"}}
 ```
 
 Which generates the following HTML:

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -23,7 +23,6 @@ export default Component.extend({
   tagName: 'ol',
   linkable: true,
   reverse: false,
-  classNameBindings: ['breadCrumbClass'],
   hasBlock: bool('template').readOnly(),
   currentUrl: readOnly('applicationRoute.router.url'),
   currentRouteName: readOnly('applicationRoute.controller.currentRouteName'),
@@ -39,20 +38,6 @@ export default Component.extend({
       const crumbs = this._lookupBreadCrumb(routeNames, filteredRouteNames);
 
       return get(this, 'reverse') ? crumbs.reverse() : crumbs;
-    }
-  }).readOnly(),
-
-  breadCrumbClass: computed('outputStyle', {
-    get() {
-      let className = 'breadcrumb';
-      const outputStyle = getWithDefault(this, 'outputStyle', '');
-      const lowerCaseOutputStyle = outputStyle.toLowerCase();
-
-      if (lowerCaseOutputStyle === 'foundation') {
-        className = 'breadcrumbs';
-      }
-
-      return className;
     }
   }).readOnly(),
 

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -21,7 +21,7 @@ test('routeHierarchy returns the correct number of routes', function(assert) {
 
   andThen(() => {
     const routeHierarchy = componentInstance.get('routeHierarchy');
-    const numberOfRenderedBreadCrumbs = find('#bootstrapLinkable li').length;
+    const numberOfRenderedBreadCrumbs = find('#linkable li').length;
     assert.equal(currentRouteName(), 'foo.bar.baz.index', 'correct current route name');
     assert.equal(routeHierarchy.length, 3, 'returns correct number of routes');
     assert.equal(numberOfRenderedBreadCrumbs, 3, 'renders the correct number of breadcrumbs');
@@ -34,7 +34,7 @@ test('routes that opt-out are not shown', function(assert) {
 
   andThen(() => {
     const routeHierarchy = componentInstance.get('routeHierarchy');
-    const numberOfRenderedBreadCrumbs = find('#foundationLinkable li').length;
+    const numberOfRenderedBreadCrumbs = find('#linkable li').length;
     assert.equal(currentRouteName(), 'foo.bar.baz.hidden', 'correct current route name');
     assert.equal(routeHierarchy.length, 3, 'returns correct number of routes');
     assert.equal(numberOfRenderedBreadCrumbs, 3, 'renders the correct number of breadcrumbs');
@@ -46,7 +46,7 @@ test('top-level flat routes render correctly', function(assert) {
   visit('/about');
 
   andThen(() => {
-    const $breadCrumbs = find('#foundationLinkable li');
+    const $breadCrumbs = find('#linkable li');
     const routeHierarchy = componentInstance.get('routeHierarchy');
     const numberOfRenderBreadCrumbs = $breadCrumbs.length;
     assert.equal(currentRouteName(), 'about', 'correct current route name');
@@ -81,26 +81,11 @@ test('routes that are not linkable do not generate an <a> tag', function(assert)
   visit('/foo/bar/baz/');
 
   andThen(() => {
-    const listElementsLength = find('#bootstrapLinkable li').length;
-    const listAnchorElementsLength = find('#bootstrapLinkable li a').length;
+    const listElementsLength = find('#linkable li').length;
+    const listAnchorElementsLength = find('#linkable li a').length;
     assert.equal(currentRouteName(), 'foo.bar.baz.index', 'correct current route name');
     assert.equal(listElementsLength, 3, 'returns the correct number of list elements');
     assert.equal(listAnchorElementsLength, 2, 'returns the correct number of list anchor elements');
-  });
-});
-
-test('bread-crumbs component outputs the right class', function(assert) {
-  assert.expect(3);
-  visit('/foo');
-
-  andThen(() => {
-    const foundationList = find('ul#foundationLinkable');
-    const bootstrapList = find('ol#bootstrapLinkable');
-    const hasCorrectFoundationClass = foundationList.hasClass('breadcrumbs');
-    const hasCorrectBootstrapClass = bootstrapList.hasClass('breadcrumb');
-    assert.equal(currentRouteName(), 'foo.index', 'correct current route name');
-    assert.ok(hasCorrectFoundationClass, 'returns the correct Foundation class');
-    assert.ok(hasCorrectBootstrapClass, 'returns the correct Bootstrap class');
   });
 });
 
@@ -120,8 +105,8 @@ test('routes with no breadcrumb should render with their capitalized inferred na
   visit('/dessert/cookie');
 
   andThen(() => {
-    const allListItems = find('ol#bootstrapLinkable li').text();
-    const allLinkItems = find('ol#bootstrapLinkable li a').text();
+    const allListItems = find('ol#linkable li').text();
+    const allLinkItems = find('ol#linkable li a').text();
 
     const hasDessertInallList = allListItems.indexOf('Dessert') >= 0;
     const hasCookieTextInallList = allListItems.indexOf('Cookie') >= 0;
@@ -141,10 +126,10 @@ test('absence of reverse option renders breadcrumb right to left', function(asse
   visit('/foo/bar/baz');
 
   andThen(() => {
-    const numberOfRenderedBreadCrumbs = find('#bootstrapLinkable li').length;
+    const numberOfRenderedBreadCrumbs = find('#linkable li').length;
     assert.equal(numberOfRenderedBreadCrumbs, 3, 'renders the correct number of breadcrumbs');
     assert.deepEqual(
-      Ember.$('#bootstrapLinkable li').map((idx, item) => item.innerText.trim()).toArray(),
+      Ember.$('#linkable li').map((idx, item) => item.innerText.trim()).toArray(),
       ['I am Foo Index', 'I am Bar', 'I am Baz']);
   });
 });
@@ -154,10 +139,10 @@ test('reverse option = TRUE renders breadcrumb from left to right', function(ass
   visit('/foo/bar/baz');
 
   andThen(() => {
-    const numberOfRenderedBreadCrumbs = find('#reverseBootstrapLinkable li').length;
+    const numberOfRenderedBreadCrumbs = find('#reverseLinkable li').length;
     assert.equal(numberOfRenderedBreadCrumbs, 3, 'renders the correct number of breadcrumbs');
     assert.deepEqual(
-      Ember.$('#reverseBootstrapLinkable li').map((idx, item) => item.innerText.trim()).toArray(),
+      Ember.$('#reverseLinkable li').map((idx, item) => item.innerText.trim()).toArray(),
       ['I am Baz', 'I am Bar', 'I am Foo Index']);
   });
 });
@@ -193,16 +178,16 @@ test('bread-crumbs change when the route is changed', function(assert) {
   visit('/foo/bar/baz');
 
   andThen(() => {
-    const lastCrumbText = find('#bootstrapLinkable li:last-child a').text().trim();
+    const lastCrumbText = find('#linkable li:last-child a').text().trim();
 
     assert.equal(currentRouteName(), 'foo.bar.baz.index', 'correct current route name');
     assert.equal(lastCrumbText, 'I am Baz', 'renders the correct last breadcrumb');
   });
 
-  click('#bootstrapLinkable li:first-child a');
+  click('#linkable li:first-child a');
 
   andThen(() => {
-    const lastCrumbText = find('#bootstrapLinkable li:last-child a').text().trim();
+    const lastCrumbText = find('#linkable li:last-child a').text().trim();
 
     assert.equal(currentRouteName(), 'foo.index', 'correct current route name (after transition)');
     assert.equal(lastCrumbText, 'I am Foo Index', 'renders the correct last breadcrumb (after transition)');
@@ -215,13 +200,13 @@ test('bread-crumbs component updates when dynamic segments change', function(ass
 
   andThen(() => {
     assert.equal(currentRouteName(), 'foo.bar.baz.show-with-params', 'correct current route name');
-    assert.equal(Ember.$('#bootstrapLinkable li:last-child')[0].innerText.trim(), 'Derek Zoolander', 'crumb is based on dynamic segment');
+    assert.equal(Ember.$('#linkable li:last-child')[0].innerText.trim(), 'Derek Zoolander', 'crumb is based on dynamic segment');
   });
 
   click('#hansel');
 
   andThen(() => {
     assert.equal(currentRouteName(), 'foo.bar.baz.show-with-params', 'correct current route name');
-    assert.equal(Ember.$('#bootstrapLinkable li:last-child')[0].innerText.trim(), 'Hansel McDonald', 'crumb is based on dynamic segment');
+    assert.equal(Ember.$('#linkable li:last-child')[0].innerText.trim(), 'Hansel McDonald', 'crumb is based on dynamic segment');
   });
 });

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -873,55 +873,6 @@ a.list-group-item-danger.active:focus {
   position: fixed;
 }
 
-/* foundation */
-.breadcrumbs {
-  border-style: solid;
-  border-width: 1px;
-  display: block;
-  list-style: none;
-  margin-left: 0;
-  overflow: hidden;
-  padding: 0.5625rem 0.875rem 0.5625rem;
-  background-color: whitesmoke;
-  border-color: #dddddd;
-  border-radius: 3px; }
-  .breadcrumbs > * {
-    color: #2ba6cb;
-    float: left;
-    font-size: 0.6875rem;
-    line-height: 0.6875rem;
-    margin: 0;
-    text-transform: uppercase; }
-    .breadcrumbs > *:hover a, .breadcrumbs > *:focus a {
-      text-decoration: underline; }
-    .breadcrumbs > * a {
-      color: #2ba6cb; }
-    .breadcrumbs > *.current {
-      color: #333333;
-      cursor: default; }
-      .breadcrumbs > *.current a {
-        color: #333333;
-        cursor: default; }
-      .breadcrumbs > *.current:hover, .breadcrumbs > *.current:hover a, .breadcrumbs > *.current:focus, .breadcrumbs > *.current:focus a {
-        text-decoration: none; }
-    .breadcrumbs > *.unavailable {
-      color: #999999; }
-      .breadcrumbs > *.unavailable a {
-        color: #999999; }
-      .breadcrumbs > *.unavailable:hover, .breadcrumbs > *.unavailable:hover a, .breadcrumbs > *.unavailable:focus,
-      .breadcrumbs > *.unavailable a:focus {
-        color: #999999;
-        cursor: not-allowed;
-        text-decoration: none; }
-    .breadcrumbs > *:before {
-      color: #AAAAAA;
-      content: "/";
-      margin: 0 0.75rem;
-      position: relative;
-      top: 1px; }
-    .breadcrumbs > *:first-child:before {
-      content: " ";
-      margin: 0; }
 
 /* Accessibility - hides the forward slash */
 [aria-label="breadcrumbs"] [aria-hidden="true"]:after {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,17 +1,9 @@
-<h2>Bootstrap Linkable</h2>
-{{bread-crumbs id="bootstrapLinkable"}}
+<h2>Linkable</h2>
+{{bread-crumbs id="linkable"}}
 <hr>
 
-<h2>Bootstrap Not Linkable</h2>
-{{bread-crumbs id="bootstrapNotLinkable" linkable=false}}
-<hr>
-
-<h2>Foundation Linkable</h2>
-{{bread-crumbs id="foundationLinkable" tagName="ul" outputStyle="foundation"}}
-<hr>
-
-<h2>Foundation Not Linkable</h2>
-{{bread-crumbs id="foundationNotLinkable" tagName="ul" outputStyle="foundation" linkable=false}}
+<h2>Not Linkable</h2>
+{{bread-crumbs id="notLinkable" linkable=false}}
 <hr>
 
 <h2>Custom block</h2>
@@ -26,8 +18,8 @@
 {{/bread-crumbs}}
 <hr>
 
-<h2>Reverse (bootstrap linkable)</h2>
-{{bread-crumbs id="reverseBootstrapLinkable" reverse=true}}
+<h2>Reverse (linkable)</h2>
+{{bread-crumbs id="reverseLinkable" reverse=true}}
 <hr>
 
 <h2>Custom <code>crumbClass</code></h2>


### PR DESCRIPTION
The `outputStyle` option only adds a `breadcrumbs` CSS class to the element, which can be achieved in the template calling the breadcrumb.

It is therefore not very useful and, worse, confusing to the new user that could assume that the addon comes with ties to Bootstrap and/or Foundation. At least, this is what happened to me before I read the code.

This PR removes the option and updates the documentation accordingly in order to avoid this kind of misinterpretation.

Lighter code, less ambiguous messaging, yay!