### PR TITLE
hide loading route

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -35,7 +35,7 @@ export default Component.extend({
       assert('[ember-crumbly] Could not find a curent route', currentRouteName);
 
       const routeNames = currentRouteName.split('.');
-      const filteredRouteNames = this._filterIndexRoutes(routeNames);
+      const filteredRouteNames = this._filterIndexAndLoadingRoutes(routeNames);
       const crumbs = this._lookupBreadCrumb(routeNames, filteredRouteNames);
 
       return get(this, 'reverse') ? crumbs.reverse() : crumbs;
@@ -68,8 +68,8 @@ export default Component.extend({
     return routes.join('.');
   },
 
-  _filterIndexRoutes(routeNames) {
-    return routeNames.filter((name) => name !== 'index');
+  _filterIndexAndLoadingRoutes(routeNames) {
+    return routeNames.filter((name) => !(name === 'index' || name === 'loading') );
   },
 
   _lookupRoute(routeName) {


### PR DESCRIPTION
Hi!
Our users found the idea of "loading" being in their breadcrumbs confusing, they can't click on it, it disappears, it isn't a previous or current page they're on etc.

I've opened this PR in case others have had the same issue :)

Thanks :)