### PR TITLE
disable link on last breadcrumb

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -79,7 +79,7 @@ export default Component.extend({
 
   _lookupBreadCrumb(routeNames, filteredRouteNames) {
     const defaultLinkable = get(this, 'linkable');
-    const pathLength = routeNames.length;
+    const pathLength = Math.min(routeNames.length, filteredRouteNames.length);
     const breadCrumbs = filteredRouteNames.map((name, index) => {
       const path = this._guessRoutePath(routeNames, name, index);
       const route = this._lookupRoute(path);

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -5,7 +5,6 @@ import getOwner from 'ember-getowner-polyfill';
 
 const {
   get,
-  set,
   Component,
   getWithDefault,
   assert,

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -5,6 +5,7 @@ import getOwner from 'ember-getowner-polyfill';
 
 const {
   get,
+  set,
   Component,
   getWithDefault,
   assert,
@@ -103,7 +104,7 @@ export default Component.extend({
     });
 
     if (breadCrumbs.length)
-      breadCrumbs[breadCrumbs.length - 1].linkable = false;
+      set(breadCrumbs[breadCrumbs.length - 1], 'linkable', false);
 
     return emberArray(breadCrumbs.filter((breadCrumb) => typeOf(breadCrumb) !== 'undefined'));
   }

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -102,6 +102,9 @@ export default Component.extend({
       return breadCrumb;
     });
 
+    if (breadCrumbs.length)
+      breadCrumbs[breadCrumbs.length - 1].linkable = false;
+
     return emberArray(breadCrumbs.filter((breadCrumb) => typeOf(breadCrumb) !== 'undefined'));
   }
 });

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -103,9 +103,6 @@ export default Component.extend({
       return breadCrumb;
     });
 
-    if (breadCrumbs.length)
-      set(breadCrumbs[breadCrumbs.length - 1], 'linkable', false);
-
     return emberArray(breadCrumbs.filter((breadCrumb) => typeOf(breadCrumb) !== 'undefined'));
   }
 });


### PR DESCRIPTION
Hi!
Users found having the current page's breadcrumb, the last one, be a link that did nothing confusing.
So this PR always disables linkable on the last breadcrumb.
I notice that this has been requested in #61 as well :)
