### PR TITLE
i18n support

### DIFF
--- a/addon/components/bread-crumb.js
+++ b/addon/components/bread-crumb.js
@@ -14,6 +14,7 @@ export default Component.extend({
   layout,
   tagName: 'li',
   classNameBindings: ['crumbClass'],
+  i18n: false,
 
   crumbClass: oneWay('breadCrumbs.crumbClass'),
   linkClass: oneWay('breadCrumbs.linkClass'),


### PR DESCRIPTION
Added i18n support:

Instead of using the name of the route as title, use the name as key for the i18n translation file.

You can override custom breadcrumbs, by using the `i18nTitle`:
  ```javascript
  breadCrumb: {
    i18nTitle: 'custom.i18n.key'
  }
  ```