### PR TITLE
i18n support

### DIFF
--- a/addon/components/bread-crumb.js
+++ b/addon/components/bread-crumb.js
@@ -14,6 +14,7 @@ export default Component.extend({
   layout,
   tagName: 'li',
   classNameBindings: ['crumbClass'],
+  i18n: false,
 
   crumbClass: oneWay('breadCrumbs.crumbClass'),
   linkClass: oneWay('breadCrumbs.linkClass'),

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -11,7 +11,7 @@ const {
   typeOf,
   setProperties,
   A: emberArray,
-  String: { classify }
+  String: { capitalize, dasherize }
 } = Ember;
 const {
   bool,
@@ -87,7 +87,8 @@ export default Component.extend({
       assert(`[ember-crumbly] \`route:${path}\` was not found`, route);
 
       let breadCrumb = getWithDefault(route, 'breadCrumb', {
-        title: classify(name)
+        title: capitalize(name),
+        i18nTitle: dasherize(name)
       });
 
       if (typeOf(breadCrumb) === 'null') {

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -23,6 +23,7 @@ export default Component.extend({
   tagName: 'ol',
   linkable: true,
   reverse: false,
+  i18n: false,
   classNameBindings: ['breadCrumbClass'],
   hasBlock: bool('template').readOnly(),
   currentUrl: readOnly('applicationRoute.router.url'),

--- a/addon/templates/components/bread-crumb.hbs
+++ b/addon/templates/components/bread-crumb.hbs
@@ -2,6 +2,8 @@
   {{#link-to route.path class=linkClass}}
     {{#if hasBlock}}
       {{yield this route}}
+    {{else if i18n}}
+      {{t route.i18nTitle}}  
     {{else}}
       {{route.title}}
     {{/if}}
@@ -9,6 +11,8 @@
 {{else}}
   {{#if hasBlock}}
     {{yield this route}}
+  {{else if i18n}}
+    {{t route.i18nTitle}}  
   {{else}}
     {{route.title}}
   {{/if}}

--- a/addon/templates/components/bread-crumbs.hbs
+++ b/addon/templates/components/bread-crumbs.hbs
@@ -2,6 +2,6 @@
   {{#if hasBlock}}
     {{yield this route}}
   {{else}}
-    {{bread-crumb route=route breadCrumbs=this}}
+    {{bread-crumb route=route breadCrumbs=this i18n=i18n}}
   {{/if}}
 {{/each}}


### PR DESCRIPTION
Instead of using the name of the route as title, use the name as key for the i18n translation file.

You can override custom breadcrumbs, by using the i18nTitle:

```javascript
  breadCrumb: {
    i18nTitle: 'custom.i18n.key'
  }
```