### PR TITLE
Stop using ember-new-computed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1.11
   - EMBER_TRY_SCENARIO=ember-1.12
   - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-2.0

--- a/addon/components/bread-crumb.js
+++ b/addon/components/bread-crumb.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 import layout from '../templates/components/bread-crumb';
-import computed from 'ember-new-computed';
 
 const {
-  Component
+  Component,
+  computed
 } = Ember;
 const {
   oneWay,

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
 import layout from '../templates/components/bread-crumbs';
-import computed from 'ember-new-computed';
 import getOwner from 'ember-getowner-polyfill';
 
 const {
   get,
   Component,
+  computed,
   getWithDefault,
   assert,
   typeOf,

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -6,15 +6,6 @@ module.exports = {
       dependencies: { }
     },
     {
-      name: 'ember-1.11',
-      dependencies: {
-        'ember': '~1.11.0'
-      },
-      resolutions: {
-        'ember': '~1.11.0'
-      }
-    },
-    {
       name: 'ember-1.12',
       dependencies: {
         'ember': '~1.12.0'

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-new-computed": "^1.0.3",
     "ember-getowner-polyfill": "^1.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
This addon is not needed since Ember 1.12. This also removes Ember 1.11 from the build
matrix, which I don't think it's a problem in Q4 of 2016.