### PR TITLE
Crumply disables links when you redirect to another route

### DIFF
--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -225,3 +225,18 @@ test('bread-crumbs component updates when dynamic segments change', function(ass
     assert.equal(Ember.$('#bootstrapLinkable li:last-child')[0].innerText.trim(), 'Hansel McDonald', 'crumb is based on dynamic segment');
   });
 });
+
+test('bread-crumbs change when the route is changed', function(assert) {
+  assert.expect(2);
+  visit('/foo/bar/baz?errorTest=true');
+
+  andThen(() => {
+    assert.equal(find('#bootstrapLinkable li a').length, 2, '2 out of the 3 bread-crumbs are links');
+  });
+
+  click('.error-link');
+
+  andThen(() => {
+    assert.equal(find('#bootstrapLinkable li a').length, 3, '2 out of the 4 bread-crumbs are links, there should be 3 links');
+  });
+});

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -5,4 +5,6 @@ const {
 } = Ember;
 
 export default Controller.extend({
+  queryParams: ['errorTest'],
+  errorTest: false
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -38,3 +38,7 @@
 {{bread-crumbs id="customLinkClass" linkClass="breadcrumb-link"}}
 
 {{outlet}}
+
+{{#if errorTest}}
+  {{link-to 'error link' 'foo.bar.baz.show-with-params' 1 class='error-link'}}
+{{/if}}


### PR DESCRIPTION
### ⚠️ Bug in bread-crumbs ⚠️
#### I have added a failing test to illustrate the problem. It was working with version 1.0.2 fine.

I think the problem is in here: https://github.com/poteto/ember-crumbly/blob/master/addon/components/bread-crumbs.js#L96-L99
### Explanation

When we enter a route, the last segment is not linkable. If then we transition to a child route, since a moment ago on the route the `linkable` property was set to `false`, than both the last segment and the parent one are not linkable.
### Example:

`/home/level1/level2`
- `home` => link
- `level1` => link
- `level2` => no link

When I click on a link that redirects to the `level3` route, the following happens:  

`/home/level1/level2/level3`
- `home` => link
- `level1` => link
- `level2` => no link
- `level3` => no link

`level2` was set before to not be a link and it stays this way. It should be a link though.
