### PR TITLE
83 Fix Ignoring Override on Root Routes

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -60,7 +60,7 @@ export default Component.extend({
     const routes = routeNames.slice(0, index + 1);
 
     if (routes.length === 1) {
-      let path = `${name}.index`;
+      let path = `${name}`;
 
       return (this._lookupRoute(path)) ? path : name;
     }

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -60,9 +60,7 @@ export default Component.extend({
     const routes = routeNames.slice(0, index + 1);
 
     if (routes.length === 1) {
-      let path = `${name}`;
-
-      return (this._lookupRoute(path)) ? path : name;
+      return name;
     }
 
     return routes.join('.');

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -138,7 +138,7 @@ test('bread-crumbs component accepts a block', function(assert) {
   andThen(() => {
     const listItemsText = find('#customBlock li span').text();
     assert.equal(currentRouteName(), 'animal.quadruped.cow.show', 'correct current route name');
-    assert.equal(listItemsText, 'Animals at the ZooCowsMary (5 years old)', 'returns the right text');
+    assert.equal(listItemsText, 'Derek Zoolander\'s Zoo for Animals Who Can\'t Read Good and Want to Do Other Stuff Good TooCowsMary (5 years old)', 'returns the right text');
   });
 });
 
@@ -172,7 +172,7 @@ test('absence of reverse option renders breadcrumb right to left', function(asse
     assert.equal(numberOfRenderedBreadCrumbs, 3, 'renders the correct number of breadcrumbs');
     assert.deepEqual(
       Ember.$('#bootstrapLinkable li').map((idx, item) => item.innerText.trim()).toArray(),
-      ['I am Foo Index', 'I am Bar', 'I am Baz']);
+      ['I am Foo', 'I am Bar', 'I am Baz']);
   });
 });
 
@@ -185,7 +185,7 @@ test('reverse option = TRUE renders breadcrumb from left to right', function(ass
     assert.equal(numberOfRenderedBreadCrumbs, 3, 'renders the correct number of breadcrumbs');
     assert.deepEqual(
       Ember.$('#reverseBootstrapLinkable li').map((idx, item) => item.innerText.trim()).toArray(),
-      ['I am Baz', 'I am Bar', 'I am Foo Index']);
+      ['I am Baz', 'I am Bar', 'I am Foo']);
   });
 });
 
@@ -232,7 +232,7 @@ test('bread-crumbs change when the route is changed', function(assert) {
     const lastCrumbText = find('#bootstrapLinkable li:last-child a').text().trim();
 
     assert.equal(currentRouteName(), 'foo.index', 'correct current route name (after transition)');
-    assert.equal(lastCrumbText, 'I am Foo Index', 'renders the correct last breadcrumb (after transition)');
+    assert.equal(lastCrumbText, 'I am Foo', 'renders the correct last breadcrumb (after transition)');
   });
 });
 


### PR DESCRIPTION
Not sure if this is the correct fix but here is a possible solution.  

Questions:

Should an index in a route override the route itself?  Right now it seems to do a hybrid of index at root level but route override everywhere else.

In the `bread-crumbs component accepts a block` test

the path /animal/quadruped/cow/show

all levels of the path have index in the route the current fix would use route override instead of index at root levels.