### PR TITLE
Fix Ignoring Override on Root Routes

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -60,9 +60,13 @@ export default Component.extend({
     const routes = routeNames.slice(0, index + 1);
 
     if (routes.length === 1) {
-      let path = `${name}.index`;
-
-      return (this._lookupRoute(path)) ? path : name;
+      if (routeNames.length === 2 && routeNames[1] === 'index') {
+        let path = `${name}.index`;
+        
+        return (this._lookupRoute(path)).get('breadCrumb') ? path : name;
+      }
+      
+      return name;
     }
 
     return routes.join('.');


### PR DESCRIPTION
Enhanced implementation of https://github.com/poteto/ember-crumbly/pull/101 for problem https://github.com/poteto/ember-crumbly/issues/83.

Proposed fix by @mrkirchner did not work if the `index` route did override the breadcrumb.