### PR TITLE
fix ember-getowner-polyfill deprication

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import layout from '../templates/components/bread-crumbs';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   get,
@@ -10,6 +9,7 @@ const {
   assert,
   typeOf,
   setProperties,
+  getOwner,
   A: emberArray,
   String: { classify }
 } = Ember;

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.1.0",
-    "ember-getowner-polyfill": "^1.0.0"
+    "ember-cli-htmlbars": "^1.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Fix for deprecation: 
```
ember-getowner-polyfill is now a true polyfill. Use Ember.getOwner directly instead of importing from ember-getowner-polyfill [deprecation id: ember-getowner-polyfill.import]
```