### PR TITLE
removed ember-getowner-polyfill in favor of Ember.getOwner

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import layout from '../templates/components/bread-crumbs';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   get,
@@ -73,7 +72,7 @@ export default Component.extend({
   },
 
   _lookupRoute(routeName) {
-    return getOwner(this).lookup(`route:${routeName}`);
+    return Ember.getOwner(this).lookup(`route:${routeName}`);
   },
 
   _lookupBreadCrumb(routeNames, filteredRouteNames) {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.1.0",
-    "ember-getowner-polyfill": "^1.0.0"
+    "ember-cli-htmlbars": "^1.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
`Ember.getOwner` [was introduced in Ember v2.3](http://emberjs.com/deprecations/v2.x/#toc_injected-container-access), so there's no need for the polyfill anymore, unless consuming apps are still on a version of Ember older than 2.3.