### PR TITLE
use Ember.getOwner

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import layout from '../templates/components/bread-crumbs';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   get,
@@ -13,6 +12,7 @@ const {
   isPresent,
   typeOf,
   setProperties,
+  getOwner,
   A: emberArray,
   String: { classify }
 } = Ember;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.1.0",
-    "ember-getowner-polyfill": "^1.1.1"
+    "ember-getowner-polyfill": "^1.2.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
- Updates to latest getOwner polyfill syntax (https://github.com/rwjblue/ember-getowner-polyfill/commit/4e65009b7eb455d971c3566e47ca4c99799bf90c?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8)
- Fixes deprecation introduced in Ember 2.12 update: 
```
DEPRECATION: ember-getowner-polyfill is now a true polyfill. Use Ember.getOwner directly instead of importing from ember-getowner-polyfill [deprecation id: ember-getowner-polyfill.import]
```