### PR TITLE
Support engine's route owner in _lookupRoute

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -82,7 +82,10 @@ export default Component.extend({
 
   _lookupRoute(routeName) {
     let routeOwner = getOwner(this);
-    let engineInfo = get(this, 'routing.router')._engineInfoByRoute[routeName];
+    let engineInfo;
+    if (get(this, 'routing.router')._engineInfoByRoute) {
+      engineInfo = get(this, 'routing.router')._engineInfoByRoute[routeName];
+    }
 
     if (engineInfo) {
       let engineInstance = get(this, 'routing.router')._getEngineInstance(engineInfo);

--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -14,6 +14,7 @@ const {
   setProperties,
   getOwner,
   A: emberArray,
+  inject,
   String: { classify }
 } = Ember;
 const {
@@ -28,6 +29,7 @@ export default Component.extend({
   reverse: false,
   classNameBindings: ['breadCrumbClass'],
   hasBlock: bool('template').readOnly(),
+  routing: inject.service('-routing'),
   currentUrl: readOnly('applicationRoute.router.url'),
   currentRouteName: readOnly('applicationRoute.controller.currentRouteName'),
 
@@ -79,7 +81,19 @@ export default Component.extend({
   },
 
   _lookupRoute(routeName) {
-    return getOwner(this).lookup(`route:${routeName}`);
+    let routeOwner = getOwner(this);
+    let engineInfo = get(this, 'routing.router')._engineInfoByRoute[routeName];
+
+    if (engineInfo) {
+      let engineInstance = get(this, 'routing.router')._getEngineInstance(engineInfo);
+
+      routeOwner = engineInstance;
+      routeName = engineInfo.localFullName;
+    }
+
+    let fullRouteName = `route:${routeName}`;
+
+    return routeOwner.lookup(fullRouteName);
   },
 
   _lookupBreadCrumb(routeNames, filteredRouteNames) {


### PR DESCRIPTION
Per issue #100, currently the bread-crumbs component fails to find the route object it needs if the route comes from an engine application. I re-used some of the internal logic from the router service so that the _lookupRoute() can handle routes that belong to an Ember Engines add-on as well as the main application. 