### PR TITLE
Allow i18n service to be used to translate bread crumbs

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -82,10 +82,15 @@ export default Component.extend({
     return getOwner(this).lookup(`route:${routeName}`);
   },
 
+  _lookupi18n() {
+    return getOwner(this).lookup('service:i18n');
+  },
+
   _lookupBreadCrumb(routeNames, filteredRouteNames) {
     const defaultLinkable = get(this, 'linkable');
     const pathLength = filteredRouteNames.length;
     const breadCrumbs = emberArray();
+    const i18nService = this._lookupi18n();
 
     filteredRouteNames.map((name, index) => {
       let path = this._guessRoutePath(routeNames, name, index);
@@ -105,7 +110,7 @@ export default Component.extend({
         });
       } else {
         let breadCrumb = copy(getWithDefault(route, 'breadCrumb', {
-          title: classify(name)
+
         }));
 
         if (typeOf(breadCrumb) === 'null') {
@@ -115,7 +120,15 @@ export default Component.extend({
             path = breadCrumb.path;
           }
 
+          let title = get(breadCrumb, 'title') || classify(name);
+          let i18nTitle = get(breadCrumb, 'i18nTitle');
+
+          if (i18nTitle && i18nService) {
+            title = i18nService.t(i18nTitle);
+          }
+
           setProperties(breadCrumb, {
+            title,
             path,
             isHead,
             isTail,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ember-data": "^2.8.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-i18n": "5.1.0",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-suave": "4.0.0",

--- a/tests/acceptance/integration-test.js
+++ b/tests/acceptance/integration-test.js
@@ -60,6 +60,22 @@ test('top-level flat routes render correctly', function(assert) {
   });
 });
 
+test('i18n is used to translate when provide', function(assert) {
+  assert.expect(4);
+  visit('/i18n');
+
+  andThen(() => {
+    const $breadCrumbs = find('#bootstrapLinkable li');
+    componentInstance = lookupComponent(applicationInstance, 'bread-crumbs');
+    const routeHierarchy = componentInstance.get('routeHierarchy');
+    const numberOfRenderBreadCrumbs = $breadCrumbs.length;
+    assert.equal(currentRouteName(), 'i18n', 'correct current route name');
+    assert.equal(routeHierarchy.length, 1, 'returns correct number of routes');
+    assert.equal(numberOfRenderBreadCrumbs, 1, 'renders the correct number of breadcrumbs');
+    assert.equal($breadCrumbs.first().text().trim(), 'About Derek Zoolander', 'uses i18n to translate');
+  });
+});
+
 test('routes can set dynamic breadcrumb props', function(assert) {
   assert.expect(5);
   visit('/foo/bar/baz/show');

--- a/tests/dummy/app/i18n/route.js
+++ b/tests/dummy/app/i18n/route.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  breadCrumb: {
+    i18nTitle: 'breadCrumb.about'
+  }
+});

--- a/tests/dummy/app/locales/en/translations.js
+++ b/tests/dummy/app/locales/en/translations.js
@@ -1,0 +1,5 @@
+export default {
+  breadCrumb: {
+    about: 'About Derek Zoolander'
+  }
+};

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -34,6 +34,7 @@ Router.map(function() {
   });
 
   this.route('about');
+  this.route('i18n');
 });
 
 export default Router;


### PR DESCRIPTION
I wanted to use your add on for creating bread crumbs, but I had a localized application.
I was able to replace this
```
import Route from '@ember/routing/route';
import { inject as service } from '@ember/service';
import { computed, get } from '@ember/object';

export default Route.extend({
  i18n: service(),

 breadCrumb: computed({
    get() {
      let i18n = get(this, 'i18n');
 
      return {
        title: i18n.t('breadcrumb.cycleCountReconcile')
      };
    }
 })
});
```
with this
```
import Route from '@ember/routing/route';

export default Route.extend({
  breadCrumb: {
    i18nTitle: 'breadcrumb.cycleCountReconcile'
  }
});
```

The i18n service is not injected into your adding, but looked up like routes are. This way if the service is not available, it wont use it. The end user will have to install ember-i18n on their own, this addon does not created a dependency on it.

I chose to use i18nTitle to trigger the need to translate. If i18nTitle and title are both specified in the breadCrumb, i18nTitle will be used.
