### PR TITLE
engine support

### DIFF
--- a/addon/components/bread-crumbs.js
+++ b/addon/components/bread-crumbs.js
@@ -28,8 +28,8 @@ export default Component.extend({
   classNameBindings: ['breadCrumbClass'],
   hasBlock: bool('template').readOnly(),
   routing: service('-routing'),
-  currentUrl: readOnly('applicationRoute.router.url'),
-  currentRouteName: readOnly('applicationRoute.controller.currentRouteName'),
+  currentUrl: readOnly('routing.currentURL'),
+  currentRouteName: readOnly('routing.currentRouteName'),
 
   routeHierarchy: computed('currentUrl', 'currentRouteName', 'reverse', {
     get() {
@@ -68,11 +68,22 @@ export default Component.extend({
 
     if (routes.length === 1) {
       let path = `${name}.index`;
-
-      return (this._lookupRoute(path)) ? path : name;
+      let pathName = this._lookupRoute(path) ? path : name;
+      return this._trimEngineMountName(pathName);
     }
 
-    return routes.join('.');
+    return this._trimEngineMountName(routes.join('.'));
+  },
+
+  _trimEngineMountName(pathName) {
+    let owner = getOwner(this);
+    let { mountPoint } = owner;
+    if(mountPoint) {
+      return pathName.split('.')
+        .splice(1)
+        .join('.');
+    }
+    return pathName;
   },
 
   _filterIndexAndLoadingRoutes(routeNames) {

--- a/addon/initializers/crumbly.js
+++ b/addon/initializers/crumbly.js
@@ -1,9 +1,0 @@
-export function initialize() {
-  const application = arguments[1] || arguments[0];
-  application.inject('component:bread-crumbs', 'applicationRoute', 'route:application');
-}
-
-export default {
-  name: 'crumbly',
-  initialize
-};

--- a/app/initializers/crumbly.js
+++ b/app/initializers/crumbly.js
@@ -1,1 +1,0 @@
-export { default, initialize } from 'ember-crumbly/initializers/crumbly';


### PR DESCRIPTION
routing service has been injected in component, so there is no need of initialiser, and ember-engine addon has extended the link-to component prefixing the mountPoint in the route name .

Check this link [Ember-engine](https://github.com/ember-engines/ember-engines/blob/master/packages/ember-engines/addon/components/link-to-component.js)